### PR TITLE
Add support for `on: workflow_dispatch` on GitHub actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
Add support for `on: workflow_dispatch` in the GitHub Actions workflow file.

* Modify `.github/workflows/ci.yml` to include `workflow_dispatch:` in the `on:` section, allowing the workflow to be triggered on demand.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/rizwankce/Storage/pull/7?shareId=15184cf4-6f54-4a07-9f9d-f732256c7559).