### PR TITLE
Fix directory creation on Linux and update tests

### DIFF
--- a/Storage/Classes/Storage.swift
+++ b/Storage/Classes/Storage.swift
@@ -8,7 +8,9 @@ public protocol KeyValueStorable: AnyObject {
     func synchronize() -> Bool
 }
 
+#if canImport(Darwin)
 extension NSUbiquitousKeyValueStore: KeyValueStorable {}
+#endif
 
 /// A class that provides a simple way to store and retrieve Codable objects.
 /// The `Storage` class supports different storage types such as cache, document, and user defaults.
@@ -24,13 +26,22 @@ public final class Storage<T> where T: Codable {
     /// - Parameters:
     ///   - storageType: The type of storage to use (cache, document, or user defaults).
     ///   - filename: The name of the file to store the data.
-    ///   - ubiquitousStore: Optional KeyValueStorable instance for .ubiquitousKeyValueStore type (defaults to NSUbiquitousKeyValueStore.default)
+    ///   - ubiquitousStore: Optional KeyValueStorable instance for .ubiquitousKeyValueStore type (defaults to platform specific store if available)
+#if canImport(Darwin)
     public init(storageType: StorageType, filename: String, ubiquitousStore: KeyValueStorable? = NSUbiquitousKeyValueStore.default) {
         self.ubiquitousStore = ubiquitousStore
         self.type = storageType
         self.filename = filename
         createFolderIfNotExists()
     }
+#else
+    public init(storageType: StorageType, filename: String, ubiquitousStore: KeyValueStorable? = nil) {
+        self.ubiquitousStore = ubiquitousStore
+        self.type = storageType
+        self.filename = filename
+        createFolderIfNotExists()
+    }
+#endif
 
     /// Saves the given object to the specified storage type.
     ///
@@ -116,7 +127,7 @@ public final class Storage<T> where T: Codable {
 
             try? FileManager.default.removeItem(at: folder)
         }
-        try? fileManager.createDirectory(at: folder, withIntermediateDirectories: false, attributes: nil)
+        try? fileManager.createDirectory(at: folder, withIntermediateDirectories: true, attributes: nil)
     }
 
     /// Clears the stored data from the specified storage type.

--- a/Tests/StorageTypeTests.swift
+++ b/Tests/StorageTypeTests.swift
@@ -5,12 +5,14 @@ class StorageTypeTests: XCTestCase {
     func testCacheDirectory() {
         let storageType = StorageType.cache
         let folder = storageType.folder
-        XCTAssertTrue(folder.path.contains("Caches"), "Cache directory path should contain 'Caches'")
+        let expected = NSSearchPathForDirectoriesInDomains(.cachesDirectory, .userDomainMask, true).first!
+        XCTAssertTrue(folder.path.hasPrefix(expected), "Cache directory should be inside the system caches directory")
     }
 
     func testDocumentDirectory() {
         let storageType = StorageType.document
         let folder = storageType.folder
-        XCTAssertTrue(folder.path.contains("Documents"), "Document directory path should contain 'Documents'")
+        let expected = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).first!
+        XCTAssertTrue(folder.path.hasPrefix(expected), "Document directory should be inside the system documents directory")
     }
 }


### PR DESCRIPTION
## Summary
- conditionally extend `NSUbiquitousKeyValueStore` only on Apple platforms and update `Storage` initializer
- create storage folders with intermediate directories so saving works on Linux
- adjust unit tests to check directories more generically

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_e_683f60bc22bc832bb8402b2bdbc3e589