### PR TITLE
Add jobs table with refresh

### DIFF
--- a/Storage/Classes/Storage.swift
+++ b/Storage/Classes/Storage.swift
@@ -8,7 +8,9 @@ public protocol KeyValueStorable: AnyObject {
     func synchronize() -> Bool
 }
 
+#if !os(Linux)
 extension NSUbiquitousKeyValueStore: KeyValueStorable {}
+#endif
 
 /// A class that provides a simple way to store and retrieve Codable objects.
 /// The `Storage` class supports different storage types such as cache, document, and user defaults.
@@ -25,12 +27,21 @@ public final class Storage<T> where T: Codable {
     ///   - storageType: The type of storage to use (cache, document, or user defaults).
     ///   - filename: The name of the file to store the data.
     ///   - ubiquitousStore: Optional KeyValueStorable instance for .ubiquitousKeyValueStore type (defaults to NSUbiquitousKeyValueStore.default)
+#if !os(Linux)
     public init(storageType: StorageType, filename: String, ubiquitousStore: KeyValueStorable? = NSUbiquitousKeyValueStore.default) {
         self.ubiquitousStore = ubiquitousStore
         self.type = storageType
         self.filename = filename
         createFolderIfNotExists()
     }
+#else
+    public init(storageType: StorageType, filename: String, ubiquitousStore: KeyValueStorable? = nil) {
+        self.ubiquitousStore = ubiquitousStore
+        self.type = storageType
+        self.filename = filename
+        createFolderIfNotExists()
+    }
+#endif
 
     /// Saves the given object to the specified storage type.
     ///


### PR DESCRIPTION
## Summary
- show jobs in a table view in the example app
- pull to refresh loads data from storage or fetches from remote
- allow Storage to build on Linux by guarding NSUbiquitousKeyValueStore usage

## Testing
- `swift test -v` *(fails: 3 failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_683f6187112c832b886e52b80b274f31