### PR TITLE
Fix clear() to remove fileURL

### DIFF
--- a/Storage/Classes/Storage.swift
+++ b/Storage/Classes/Storage.swift
@@ -123,7 +123,7 @@ public final class Storage<T> where T: Codable {
     public func clear() {
         switch type {
             case .cache, .document:
-                try? FileManager.default.removeItem(at: type.folder)
+                try? FileManager.default.removeItem(at: fileURL)
             case .userDefaults:
                 UserDefaults.standard.removeObject(forKey: type.userDefaultsKey + ".\(filename)")
             case .ubiquitousKeyValueStore:


### PR DESCRIPTION
## Summary
- remove just the file instead of entire folder when clearing `.cache` and `.document`

## Testing
- `swift test` *(fails: cannot find type 'NSUbiquitousKeyValueStore' in scope)*

------
https://chatgpt.com/codex/tasks/task_e_683f62a5cf80832ba46a69537d8bd3ca