### PR TITLE
Add ubiquitous store to storage types doc

### DIFF
--- a/Storage/Classes/Storage.swift
+++ b/Storage/Classes/Storage.swift
@@ -11,7 +11,7 @@ public protocol KeyValueStorable: AnyObject {
 extension NSUbiquitousKeyValueStore: KeyValueStorable {}
 
 /// A class that provides a simple way to store and retrieve Codable objects.
-/// The `Storage` class supports different storage types such as cache, document, and user defaults.
+/// The `Storage` class supports different storage types such as cache, document, user defaults, and ubiquitous key-value store.
 /// 
 /// - Generic T: The type of object to store; must conform to `Codable`.
 public final class Storage<T> where T: Codable {


### PR DESCRIPTION
## Summary
- clarify doc comment above `Storage` class to mention ubiquitous key-value store

## Testing
- `swift test -l` *(fails: cannot find type 'NSUbiquitousKeyValueStore' in scope)*

------
https://chatgpt.com/codex/tasks/task_e_683f62abb098832bb48f4f54264589bb